### PR TITLE
Also search for streamName ending with \u0000

### DIFF
--- a/src/ole-compound-doc/storage.js
+++ b/src/ole-compound-doc/storage.js
@@ -20,7 +20,7 @@ class Storage {
   }
 
   streamFromBuffer(streamName) {
-    const streamEntry = this._dirEntry.streams[streamName]
+    const streamEntry = this._dirEntry.streams[streamName] || this._dirEntry.streams[`${streamName}\u0000`]
     if (!streamEntry) return null
 
     const doc = this._doc


### PR DESCRIPTION
Hi,

What I found was that the stream name from my .doc file ended with a null character, i.e. `WordDocument\u0000` instead of `WordDocument`. I'm interested to learn why this is the case.